### PR TITLE
Support aes-128/clear drms, use audio track names as labels

### DIFF
--- a/src/components/controls/Controls.js
+++ b/src/components/controls/Controls.js
@@ -85,7 +85,7 @@ let PlaybackLevel = (props) => {
 let Offering = (props) => {
   const store = props.videoStore;
   let offerings = Object.keys(store.availableOfferings).map(offeringKey =>
-    [offeringKey, store.availableOfferings[offeringKey].display_name || offeringKey]
+    [offeringKey, store.availableOfferings[offeringKey].display_name || offeringKey, store.availableOfferings[offeringKey].disabled || false]
   );
 
   return (
@@ -96,8 +96,8 @@ let Offering = (props) => {
         className={"offering-selection"}
         onChange={event => store.SetOffering(event.target.value)}
       >
-        {offerings.map(([offeringKey, label]) =>
-          <option key={`offering-${offeringKey}`} value={offeringKey}>
+        {offerings.map(([offeringKey, label, disabled]) =>
+          <option key={`offering-${offeringKey}`} value={offeringKey} disabled={disabled}>
             { label === "default" ? "Default Offering" : label }
           </option>
         )}

--- a/src/stores/Menu.js
+++ b/src/stores/Menu.js
@@ -185,7 +185,7 @@ class MenuStore {
         return {
           objectId: latestVersion.id,
           versionHash: latestVersion.hash,
-          name: latestVersion.meta.public && latestVersion.meta.public.name || latestVersion.meta.name || latestVersion.id,
+          name: latestVersion.meta && latestVersion.meta.public && latestVersion.meta.public.name || latestVersion.meta && latestVersion.meta.name || latestVersion.id,
           metadata: latestVersion.meta
         };
       })

--- a/src/stores/Tracks.js
+++ b/src/stores/Tracks.js
@@ -113,6 +113,7 @@ class Tracks {
         }));
 
         return {
+          label: audioName,
           initSegmentUrl: initSegmentUrl,
           segments: audioSegmentUrls
         };
@@ -257,7 +258,7 @@ class Tracks {
 
           this.audioTracks.push({
             trackId,
-            label: "Audio",
+            label: track.label || "Audio",
             trackType: "audio",
             entries: [],
             max: 0,

--- a/src/stores/Video.js
+++ b/src/stores/Video.js
@@ -219,6 +219,8 @@ class VideoStore {
           }
         }
 
+        if(!offerings) { throw Error("No offerings with HLS clear or aes-128 playout found."); }
+
         this.availableOfferings = offerings;
 
         const playoutOptions = offeringPlayoutOptions[this.offeringKey];

--- a/src/stores/Video.js
+++ b/src/stores/Video.js
@@ -210,7 +210,7 @@ class VideoStore {
         if(!playoutOptions || !playoutOptions["hls"] || !(playoutOptions["hls"].playoutMethods.clear || playoutOptions["hls"].playoutMethods["aes-128"])) {
           console.error(`HLS Clear and AES-128 not supported by ${this.offeringKey} offering.`);
 
-          const response = yield this.SetSupportedOffering({versionHash: videoObject.versionHash, browserSupportedDrms});
+          const response = yield this.GetSupportedOffering({versionHash: videoObject.versionHash, browserSupportedDrms});
           this.offeringKey = response.offeringKey;
           playoutOptions = response.playoutOptions;
         }
@@ -350,7 +350,7 @@ class VideoStore {
     }
   });
 
-  SetSupportedOffering = flow(function * ({versionHash, browserSupportedDrms}) {
+  GetSupportedOffering = flow(function * ({versionHash, browserSupportedDrms}) {
     let setNewOffering = false;
     const offeringPlayoutOptions = {};
     let offeringKey;


### PR DESCRIPTION
Set default offering as first found with HLS clear or aes-128 and disable others in dropdown menu. Also, use audio track name as label.