### PR TITLE
Add ability to save to multiple offerings

### DIFF
--- a/src/components/Components.js
+++ b/src/components/Components.js
@@ -13,7 +13,7 @@ export const BackButton = ({onClick, className=""}) => {
   );
 };
 
-export const Checkbox = ({value, onChange, toolTip, className=""}) => {
+export const Checkbox = ({value, onChange, toolTip, className="", size="xs"}) => {
   const checkbox = (
     <div className={`checkbox-container ${className || ""}`}>
       <div
@@ -21,7 +21,7 @@ export const Checkbox = ({value, onChange, toolTip, className=""}) => {
           event.stopPropagation();
           onChange(!value);
         }}
-        className={`checkbox ${value ? "checked" : ""}`}
+        className={`checkbox ${value ? "checked" : ""} checkbox-${size}`}
       />
     </div>
   );
@@ -35,4 +35,44 @@ export const Checkbox = ({value, onChange, toolTip, className=""}) => {
   }
 
   return checkbox;
+};
+
+export const Radio = ({
+  label="",
+  value,
+  checked,
+  onChange,
+  toolTip,
+  className="",
+  id,
+  disabled
+}) => {
+  const radio = (
+    <div className={`radio-container ${className || ""}`}>
+      <button
+        onClick={(event) => {
+          event.stopPropagation();
+          onChange(value);
+        }}
+        id={id}
+        type="button"
+        role="radio"
+        className="radio-button"
+        disabled={disabled}
+      >
+        <span className={`radio ${checked ? "checked" : ""}`} />
+      </button>
+      <label htmlFor={id} className={disabled ? "label-disabled" : ""}>{ label }</label>
+    </div>
+  );
+
+  if(toolTip) {
+    return (
+      <ToolTip content={toolTip}>
+        { radio }
+      </ToolTip>
+    );
+  }
+
+  return radio;
 };

--- a/src/components/Components.js
+++ b/src/components/Components.js
@@ -13,7 +13,7 @@ export const BackButton = ({onClick, className=""}) => {
   );
 };
 
-export const Checkbox = ({value, onChange, toolTip, className="", size="xs"}) => {
+export const Checkbox = ({value, onChange, toolTip, className="", size="xs", title=""}) => {
   const checkbox = (
     <div className={`checkbox-container ${className || ""}`}>
       <div
@@ -21,6 +21,7 @@ export const Checkbox = ({value, onChange, toolTip, className="", size="xs"}) =>
           event.stopPropagation();
           onChange(!value);
         }}
+        title={title}
         className={`checkbox ${value ? "checked" : ""} checkbox-${size}`}
       />
     </div>

--- a/src/components/Overlay.js
+++ b/src/components/Overlay.js
@@ -13,6 +13,8 @@ const frameSpread = 10;
 @inject("entryStore")
 @observer
 class Overlay extends React.Component {
+  _isMounted = false;
+
   constructor(props) {
     super(props);
 
@@ -56,10 +58,12 @@ class Overlay extends React.Component {
           height = width / videoAspectRatio;
         }
 
-        this.setState({
-          videoHeight: height,
-          videoWidth: width
-        });
+        if(this._isMounted) {
+          this.setState({
+            videoHeight: height,
+            videoWidth: width
+          });
+        }
       }, debounceInterval);
 
       this.lastUpdate = performance.now();
@@ -69,6 +73,7 @@ class Overlay extends React.Component {
   }
 
   componentDidMount() {
+    this._isMounted = true;
     this.setState({
       DisposeDrawReaction: reaction(
         () => {
@@ -92,6 +97,7 @@ class Overlay extends React.Component {
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
     if(this.state.DisposeDrawReaction) {
       this.state.DisposeDrawReaction();
     }

--- a/src/components/controls/Controls.js
+++ b/src/components/controls/Controls.js
@@ -84,9 +84,11 @@ let PlaybackLevel = (props) => {
 
 let Offering = (props) => {
   const store = props.videoStore;
-  let offerings = Object.keys(store.availableOfferings).map(offeringKey =>
-    [offeringKey, store.availableOfferings[offeringKey].display_name || offeringKey, store.availableOfferings[offeringKey].disabled || false]
-  );
+  let offerings = Object.keys(store.availableOfferings)
+    .sort((a, b) => a.localeCompare(b, undefined, {numeric: true, sensitivity: "base"}))
+    .map(offeringKey =>
+      [offeringKey, store.availableOfferings[offeringKey].display_name || offeringKey, store.availableOfferings[offeringKey].disabled || false]
+    );
 
   return (
     <ToolTip content={<span>Offering</span>}>

--- a/src/components/controls/Save.js
+++ b/src/components/controls/Save.js
@@ -29,8 +29,8 @@ class Save extends React.Component {
         </ToolTip>
         <SaveModal
           show={this.state.showModal}
-          HandleSubmit={() => {
-            this.props.editStore.Save();
+          HandleSubmit={(trimOfferings) => {
+            this.props.editStore.Save({trimOfferings});
           }}
           HandleClose={() => this.setState({showModal: false})}
         />

--- a/src/components/controls/Save.js
+++ b/src/components/controls/Save.js
@@ -3,20 +3,38 @@ import {observer, inject} from "mobx-react";
 import {IconButton, ToolTip} from "elv-components-js";
 import SaveIcon from "../../static/icons/Save.svg";
 import LoadingElement from "elv-components-js/src/components/LoadingElement";
+import SaveModal from "./SaveModal";
 
 @inject("editStore")
+@inject("videoStore")
 @observer
 class Save extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showModal: false
+    };
+  }
+
   render() {
     return (
       <LoadingElement loading={this.props.editStore.saving} loadingClassname="header-icon save-icon-loading">
         <ToolTip content={<span>Save</span>}>
           <IconButton
-            onClick={this.props.editStore.Save}
+            onClick={() => this.setState({showModal: true})}
             icon={SaveIcon}
             className={`header-icon save-icon ${this.props.editStore.saveFailed ? "save-failed" : ""}`}
           />
         </ToolTip>
+        <SaveModal
+          show={this.state.showModal}
+          HandleSubmit={() => {
+            this.props.editStore.Save();
+            this.setState({showModal: false});
+          }}
+          HandleClose={() => this.setState({showModal: false})}
+        />
       </LoadingElement>
     );
   }

--- a/src/components/controls/Save.js
+++ b/src/components/controls/Save.js
@@ -31,7 +31,6 @@ class Save extends React.Component {
           show={this.state.showModal}
           HandleSubmit={() => {
             this.props.editStore.Save();
-            this.setState({showModal: false});
           }}
           HandleClose={() => this.setState({showModal: false})}
         />

--- a/src/components/controls/SaveModal.js
+++ b/src/components/controls/SaveModal.js
@@ -37,7 +37,7 @@ const TrimForm = observer(({
 });
 
 const OfferingsTable = (() => {
-  const offerings = Object.keys(videoStore.availableOfferings || {});
+  const offerings = Object.keys(videoStore.availableOfferings || {}).sort((a, b) => a.localeCompare(b, undefined, {numeric: true, sensitivity: "base"}));
   const [allSelected, setAllSelected] = useState(false);
 
   const firstUpdate = useRef(true);
@@ -88,7 +88,7 @@ const OfferingsTable = (() => {
       </header>
       <Observer>
         {
-          () => offerings.sort().map(offeringKey => {
+          () => offerings.map(offeringKey => {
             const {exit, entry, durationTrimmed} = videoStore.availableOfferings[offeringKey];
 
             return (

--- a/src/components/controls/SaveModal.js
+++ b/src/components/controls/SaveModal.js
@@ -36,10 +36,10 @@ const TrimForm = observer(({
   );
 });
 
-const AdditionalOfferings = observer(() => {
-  const additionalOfferings = Object.keys(videoStore.availableOfferings || {}).filter(offeringKey => offeringKey !== videoStore.offeringKey);
+const OfferingsTable = observer(() => {
+  const offerings = Object.keys(videoStore.availableOfferings || {});
 
-  if(additionalOfferings.length === 0) { return null; }
+  if(offerings.length === 0) { return null; }
 
   return (
     <>
@@ -53,7 +53,7 @@ const AdditionalOfferings = observer(() => {
           <div className="table-col">Duration (Trimmed)</div>
         </header>
         {
-          additionalOfferings.map(offeringKey => {
+          offerings.map(offeringKey => {
             const {exit, entry, durationTrimmed} = videoStore.availableOfferings[offeringKey];
 
             return (
@@ -85,7 +85,6 @@ const AdditionalOfferings = observer(() => {
 const TrimOptions = () => {
   const [trimOption, setTrimOption] = useState("CURRENT");
   const clipChanged = editStore.DetermineTrimChange().clipChanged;
-  const additionalOfferings = Object.keys(videoStore.availableOfferings || {}).filter(offeringKey => offeringKey !== videoStore.offeringKey);
 
   if(!clipChanged) { return null; }
 
@@ -111,13 +110,11 @@ const TrimOptions = () => {
           value="MULTIPLE"
           checked={trimOption === "MULTIPLE"}
           onChange={(value) => setTrimOption(value)}
-          disabled={additionalOfferings.length === 0}
-          toolTip={additionalOfferings.length === 0 ? "No additional offerings found" : undefined}
         />
       </div>
       {
         trimOption === "MULTIPLE" &&
-        <AdditionalOfferings />
+        <OfferingsTable />
       }
     </>
   );

--- a/src/components/controls/SaveModal.js
+++ b/src/components/controls/SaveModal.js
@@ -1,0 +1,144 @@
+import React, {useState} from "react";
+import {Form, Modal} from "elv-components-js";
+import {Checkbox, Radio} from "../Components";
+import {observer} from "mobx-react";
+import {videoStore, editStore} from "../../stores";
+
+const TrimForm = observer(({
+  offeringKey
+}) => {
+  const {
+    durationTrimmed,
+    durationUntrimmed,
+    exitRevised,
+    entryRevised
+  } = editStore.DetermineTrimChange();
+
+  return (
+    <>
+      <section>
+        <header className="table-row">
+          <div className="table-col flex-2"></div>
+          <div className="table-col">Duration (Untrimmed)</div>
+          <div className="table-col">Revised Entry</div>
+          <div className="table-col">Revised Exit</div>
+          <div className="table-col">Duration (Trimmed)</div>
+        </header>
+        <div className="table-row">
+          <div className="table-col flex-2">Current Offering: { offeringKey }</div>
+          <div className="table-col">{ durationUntrimmed }</div>
+          <div className="table-col">{ entryRevised }</div>
+          <div className="table-col">{ exitRevised }</div>
+          <div className="table-col">{ durationTrimmed }</div>
+        </div>
+      </section>
+    </>
+  );
+});
+
+const AdditionalOfferings = observer(() => {
+  const additionalOfferings = Object.keys(videoStore.availableOfferings || {}).filter(offeringKey => offeringKey !== videoStore.offeringKey);
+
+  if(additionalOfferings.length === 0) { return null; }
+
+  return (
+    <>
+      <section className="additional-offerings-table">
+        <header className="table-row">
+          <div className="table-col">Include</div>
+          <div className="table-col">Offering Key</div>
+          <div className="table-col">Duration (Untrimmed)</div>
+          <div className="table-col">Current Entry</div>
+          <div className="table-col">Current Exit</div>
+          <div className="table-col">Duration (Trimmed)</div>
+        </header>
+        {
+          additionalOfferings.map(offeringKey => {
+            const {exit, entry, durationTrimmed} = videoStore.availableOfferings[offeringKey];
+
+            return (
+              <div className="table-row" key={offeringKey}>
+                <div className="table-col">
+                  <Checkbox
+                    id="trimPoints"
+                    value={editStore.clipChangeOfferings[offeringKey]}
+                    onChange={(value) => {
+                      editStore.SetClipChangeOfferings({key: offeringKey, value});
+                    }}
+                    size="md"
+                  />
+                </div>
+                <div className="table-col">{offeringKey}</div>
+                <div className="table-col">{ videoStore.scaleMaxSMPTE }</div>
+                <div className="table-col">{ entry === null ? "--" : videoStore.TimeToSMPTE(entry) }</div>
+                <div className="table-col">{ exit === null ?"--" : videoStore.TimeToSMPTE(exit) }</div>
+                <div className="table-col">{ durationTrimmed === null ? "--" : videoStore.TimeToSMPTE(durationTrimmed) }</div>
+              </div>
+            );
+          })
+        }
+      </section>
+    </>
+  );
+});
+
+const TrimOptions = () => {
+  const [trimOption, setTrimOption] = useState("CURRENT");
+  const clipChanged = editStore.DetermineTrimChange().clipChanged;
+  const additionalOfferings = Object.keys(videoStore.availableOfferings || {}).filter(offeringKey => offeringKey !== videoStore.offeringKey);
+
+  if(!clipChanged) { return null; }
+
+  return (
+    <>
+      <div className="radio-label">Review video trim settings. You can choose to apply trim values exclusively to the current offering or extend them to additional offerings. Please select an option.</div>
+      <TrimForm
+        offeringKey={videoStore.offeringKey}
+      />
+      <div className="radio-item">
+        <Radio
+          id="currentOffering"
+          label="Save to Current Offering"
+          value="CURRENT"
+          checked={trimOption === "CURRENT"}
+          onChange={(value) => setTrimOption(value)}
+        />
+      </div>
+      <div className="radio-item">
+        <Radio
+          id="multipleOfferings"
+          label="Save to Multiple Offerings"
+          value="MULTIPLE"
+          checked={trimOption === "MULTIPLE"}
+          onChange={(value) => setTrimOption(value)}
+          disabled={additionalOfferings.length === 0}
+          toolTip={additionalOfferings.length === 0 ? "No additional offerings found" : undefined}
+        />
+      </div>
+      {
+        trimOption === "MULTIPLE" &&
+        <AdditionalOfferings />
+      }
+    </>
+  );
+};
+
+const SaveModal = ({show=false, HandleClose, HandleSubmit}) => {
+  if(!show) { return null; }
+
+  return (
+    <Modal className="save-modal-container">
+      <Form
+        legend="Confirm"
+        OnSubmit={HandleSubmit}
+        submitText="Save"
+        OnCancel={HandleClose}
+      >
+        <TrimOptions />
+        <div className="confirm-message">Are you sure you want to save your changes?</div>
+      </Form>
+    </Modal>
+  );
+};
+
+export default SaveModal;

--- a/src/components/controls/SaveModal.js
+++ b/src/components/controls/SaveModal.js
@@ -45,7 +45,24 @@ const OfferingsTable = observer(() => {
     <>
       <section className="additional-offerings-table">
         <header className="table-row">
-          <div className="table-col">Include</div>
+          <div className="table-col">
+            <Checkbox
+              id="includeAll"
+              size="md"
+              title="Select"
+              value={
+                JSON.stringify(editStore.clipChangeOfferings || {}) === JSON.stringify(offerings.reduce((a, v) => ({ ...a, [v]: true}), {}) || {})
+              }
+              onChange={(value) => {
+                editStore.SetClipChangeOfferings(offerings.map(offeringKey => {
+                  return {
+                    key: offeringKey,
+                    value
+                  };
+                }));
+              }}
+            />
+          </div>
           <div className="table-col">Offering Key</div>
           <div className="table-col">Duration (Untrimmed)</div>
           <div className="table-col">Current Entry</div>
@@ -63,9 +80,10 @@ const OfferingsTable = observer(() => {
                     id="trimPoints"
                     value={editStore.clipChangeOfferings[offeringKey]}
                     onChange={(value) => {
-                      editStore.SetClipChangeOfferings({key: offeringKey, value});
+                      editStore.SetClipChangeOfferings([{key: offeringKey, value}]);
                     }}
                     size="md"
+                    title="Select"
                   />
                 </div>
                 <div className="table-col">{offeringKey}</div>

--- a/src/static/stylesheets/defaults.scss
+++ b/src/static/stylesheets/defaults.scss
@@ -176,10 +176,25 @@ button {
 .checkbox {
   background-color: $elv-color-black;
   border-radius: 3px;
-  height: $elv-font-xxs;
   outline: 1px solid $color-border;
-  position: relative;
-  width: $elv-font-xxs;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &-xs {
+    height: $elv-font-xxs;
+    width: $elv-font-xxs;
+  }
+
+  &-sm {
+    height: $elv-font-xs;
+    width: $elv-font-xs;
+  }
+
+  &-md {
+    height: 14px;
+    width: 14px;
+  }
 
   &.checked {
     &::after {
@@ -187,9 +202,55 @@ button {
       content: "✓";
       font-size: $elv-font-m;
       font-weight: 600;
-      left: 0;
       position: absolute;
-      top: -0.3rem;
+    }
+  }
+}
+
+.radio-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  .label-disabled {
+    opacity: 0.5;
+  }
+}
+
+button.radio-button {
+  all: unset;
+  background-color: $elv-color-black;
+  border-radius: 100%;
+  height: $elv-font-m;
+  width: $elv-font-m;
+
+  &:hover {
+    background-color: $elv-color-black;
+  }
+
+  &:disabled {
+    pointer-events: none;
+  }
+}
+
+.radio {
+  align-items: center;
+  border-radius: 50%;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  outline: 1px solid $color-border;
+  position: relative;
+  width: 100%;
+
+  &.checked {
+    &::after {
+      content: "";
+      display: block;
+      width: 8px;
+      height: 8px;
+      background-color: $elv-color-white;
+      border-radius: 50%;
     }
   }
 }

--- a/src/static/stylesheets/defaults.scss
+++ b/src/static/stylesheets/defaults.scss
@@ -180,6 +180,7 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
 
   &-xs {
     height: $elv-font-xxs;

--- a/src/static/stylesheets/header.scss
+++ b/src/static/stylesheets/header.scss
@@ -133,3 +133,59 @@ header {
     text-align: center;
   }
 }
+
+.save-modal-container {
+  form.-elv-form {
+    width: 850px;
+  }
+
+  .confirm-message,
+  .radio-label {
+    margin: 1rem 0;
+    line-height: 1.5;
+  }
+
+  .radio-item {
+    margin-left: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  section {
+    margin-bottom: 1.5rem;
+  }
+
+  header {
+    font-weight: 700;
+  }
+
+  header,
+  .table-row {
+    display: flex;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    align-items: center;
+  }
+
+  .table-col {
+    flex: 1;
+
+    &.flex-2 {
+      flex: 2;
+      flex-basis: 1rem;
+    }
+  }
+
+  .additional-offerings-table {
+    header {
+      background-color: $elv-color-bg-dark;
+    }
+
+    .table-row:nth-child(odd) {
+      background-color: rgba($color-background-modal, 0.6)
+    }
+
+    .table-row:nth-child(even) {
+      background-color: rgba($color-background-modal, 0.1);
+    }
+  }
+}

--- a/src/stores/Edit.js
+++ b/src/stores/Edit.js
@@ -211,8 +211,10 @@ class EditStore {
   };
 
   @action.bound
-  SetClipChangeOfferings = ({key, value}) => {
-    this.clipChangeOfferings[key] = value;
+  SetClipChangeOfferings = (offeringPairs=[]) => {
+    offeringPairs.forEach(({key, value}) => {
+      this.clipChangeOfferings[key] = value;
+    });
   };
 
   @action.bound

--- a/src/stores/Edit.js
+++ b/src/stores/Edit.js
@@ -143,8 +143,7 @@ class EditStore {
 
       if(clipChanged) {
         const filteredOfferings = Object.keys(this.clipChangeOfferings || {}).filter(offeringKey => this.clipChangeOfferings[offeringKey]);
-        const currentOffering = [this.rootStore.videoStore.offeringKey];
-        const offeringsToUpdate = filteredOfferings.length > 0 ? filteredOfferings.concat(currentOffering) : currentOffering;
+        const offeringsToUpdate = filteredOfferings.length > 0 ? filteredOfferings : [this.rootStore.videoStore.offeringKey];
 
         for(let i = 0; i < offeringsToUpdate.length; i++) {
           const offering = offeringsToUpdate[i];

--- a/src/stores/Video.js
+++ b/src/stores/Video.js
@@ -160,6 +160,7 @@ class VideoStore {
     this.clipOutFrame = undefined;
 
     this.rootStore.entryStore.ClearEntries();
+    this.rootStore.trackStore.Reset();
   }
 
   @action.bound
@@ -170,7 +171,7 @@ class VideoStore {
   });
 
   @action.bound
-  SetVideo = flow(function * (videoObject, offeringKey) {
+  SetVideo = flow(function * (videoObject) {
     this.loading = true;
 
     try {
@@ -197,16 +198,42 @@ class VideoStore {
         this.availableOfferings = yield this.rootStore.client.AvailableOfferings({
           versionHash: videoObject.versionHash
         });
+
+        Object.keys(this.availableOfferings || {}).map(offeringKey => {
+          const entryPointRat = this.metadata.offerings[offeringKey].entry_point_rat;
+          const exitPointRat = this.metadata.offerings[offeringKey].exit_point_rat;
+          let entryPoint = null, exitPoint = null;
+
+          if(entryPointRat) {
+            entryPoint = FrameAccurateVideo.ParseRat(entryPointRat);
+          }
+
+          if(exitPointRat) {
+            exitPoint = FrameAccurateVideo.ParseRat(exitPointRat);
+          }
+
+          this.availableOfferings[offeringKey].entry = entryPoint;
+          this.availableOfferings[offeringKey].exit = exitPoint;
+          this.availableOfferings[offeringKey].durationTrimmed = (entryPoint === null || exitPoint === null) ? null : (exitPoint - entryPoint);
+        });
+
         const offeringPlayoutOptions = {};
         const browserSupportedDrms = (yield this.rootStore.client.AvailableDRMs() || []).filter(drm => ["clear", "aes-128"].includes(drm));
 
-        let playoutOptions = yield this.rootStore.client.PlayoutOptions({
-          versionHash: videoObject.versionHash,
-          protocols: ["hls"],
-          drms: browserSupportedDrms,
-          hlsjsProfile: false,
-          offering: this.offeringKey
-        });
+        let playoutOptions;
+        try {
+          playoutOptions = yield this.rootStore.client.PlayoutOptions({
+            versionHash: videoObject.versionHash,
+            protocols: ["hls"],
+            drms: browserSupportedDrms,
+            hlsjsProfile: false,
+            offering: this.offeringKey
+          });
+        } catch(error) {
+          // eslint-disable-next-line no-console
+          console.error(error);
+          this.rootStore.menuStore.SetErrorMessage(`Unable to load playout options for ${this.offeringKey}`);
+        }
 
         if(!playoutOptions || !playoutOptions["hls"] || !(playoutOptions["hls"].playoutMethods.clear || playoutOptions["hls"].playoutMethods["aes-128"])) {
           console.error(`HLS Clear and AES-128 not supported by ${this.offeringKey} offering.`);
@@ -273,7 +300,7 @@ class VideoStore {
           if(offering.exit_point_rat) {
             // End time is end of specified frame
             const frameRate = FrameRates[this.frameRateKey].valueOf();
-            this.primaryContentEndTime = Number((FrameAccurateVideo.ParseRat(offering.exit_point_rat) - (1 / frameRate)).toFixed(3));
+            this.primaryContentEndTime = Number((FrameAccurateVideo.ParseRat(offering.exit_point_rat)).toFixed(3));
           }
         } catch(error) {
           // eslint-disable-next-line no-console
@@ -401,6 +428,10 @@ class VideoStore {
         "mime_types"
       ]
     });
+
+    if(this.videoObject) {
+      this.videoObject.metadata = this.metadata;
+    }
   });
 
   @action.bound

--- a/src/stores/Video.js
+++ b/src/stores/Video.js
@@ -199,23 +199,7 @@ class VideoStore {
           versionHash: videoObject.versionHash
         });
 
-        Object.keys(this.availableOfferings || {}).map(offeringKey => {
-          const entryPointRat = this.metadata.offerings[offeringKey].entry_point_rat;
-          const exitPointRat = this.metadata.offerings[offeringKey].exit_point_rat;
-          let entryPoint = null, exitPoint = null;
-
-          if(entryPointRat) {
-            entryPoint = FrameAccurateVideo.ParseRat(entryPointRat);
-          }
-
-          if(exitPointRat) {
-            exitPoint = FrameAccurateVideo.ParseRat(exitPointRat);
-          }
-
-          this.availableOfferings[offeringKey].entry = entryPoint;
-          this.availableOfferings[offeringKey].exit = exitPoint;
-          this.availableOfferings[offeringKey].durationTrimmed = (entryPoint === null || exitPoint === null) ? null : (exitPoint - entryPoint);
-        });
+        this.SetOfferingClipDetails();
 
         const offeringPlayoutOptions = {};
         const browserSupportedDrms = (yield this.rootStore.client.AvailableDRMs() || []).filter(drm => ["clear", "aes-128"].includes(drm));
@@ -413,6 +397,27 @@ class VideoStore {
       offeringKey
     };
   });
+
+  @action.bound
+  SetOfferingClipDetails = () => {
+    Object.keys(this.metadata.offerings || {}).map(offeringKey => {
+      const entryPointRat = this.metadata.offerings[offeringKey].entry_point_rat;
+      const exitPointRat = this.metadata.offerings[offeringKey].exit_point_rat;
+      let entryPoint = null, exitPoint = null;
+
+      if(entryPointRat) {
+        entryPoint = FrameAccurateVideo.ParseRat(entryPointRat);
+      }
+
+      if(exitPointRat) {
+        exitPoint = FrameAccurateVideo.ParseRat(exitPointRat);
+      }
+
+      this.availableOfferings[offeringKey].entry = entryPoint;
+      this.availableOfferings[offeringKey].exit = exitPoint;
+      this.availableOfferings[offeringKey].durationTrimmed = (entryPoint === null || exitPoint === null) ? null : (exitPoint - entryPoint);
+    });
+  };
 
   ReloadMetadata = flow(function * () {
     const versionHash = this.rootStore.menuStore.selectedObject.versionHash;


### PR DESCRIPTION
Create Save dropdown with two options: 1) Save To All Offerings and 2)Save To This Offering. This only applies to metadata that changes /offerings/<offeringKey>, i.e., `entry_point_rat` and `exit_point_rat`.

<img width="306" alt="image" src="https://github.com/eluv-io/elv-video-editor/assets/91760982/2933a7a7-da35-4fd4-856d-a464f4193af0">
